### PR TITLE
Run initial commitment in background

### DIFF
--- a/source/commitment_status.py
+++ b/source/commitment_status.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class CommitmentStatus(Enum):
+    PENDING = "pending"
+    VERIFIED = "verified"
+    FAILED = "failed"

--- a/source/game.py
+++ b/source/game.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+from queue import Empty
 from secrets import randbelow
+from time import sleep
 
 from source.battleship_zk import (
     BattleshipSecret,
@@ -9,7 +11,8 @@ from source.battleship_zk import (
     setup_battleship_circuit,
     verify_hit_response,
 )
-from source.client import recv, send
+from source.client import incoming, recv, send
+from source.commitment_status import CommitmentStatus
 from source.constants import (
     HIT_STR,
     LOST_STR,
@@ -29,6 +32,7 @@ class Game:
     secret: BattleshipSecret | None = None
     commitment: str | None = None
     opponent_commitment: str | None = None
+    commitment_status: CommitmentStatus = CommitmentStatus.PENDING
 
     def __post_init__(self) -> None:
         setup_battleship_circuit()
@@ -43,7 +47,9 @@ class Game:
     def handle_my_go(self, ui: PygameUI) -> bool:
         if (
             choice := ui.wait_for_target_click(
-                self.player.board, status=TURN_MSG
+                self.player.board,
+                status=TURN_MSG,
+                commitment_status=self.commitment_status,
             )
         ) is None:
             return False
@@ -53,32 +59,48 @@ class Game:
 
         send(self.player.conn, str(coordinate))
 
-        ui.draw(self.player.board, status="Verifying opponent's proof...")
+        ui.draw(
+            self.player.board,
+            status="Verifying opponent's proof...",
+            commitment_status=self.commitment_status,
+        )
         result = verify_hit_response(
             recv(),
             guess=coordinate,
             expected_commitment=self._opponent_commitment(),
         )
-        ui.draw(self.player.board, status="Opponent's proof verified.")
+        ui.draw(
+            self.player.board,
+            status="Opponent's proof verified.",
+            commitment_status=self.commitment_status,
+        )
         hit = result in {HIT_STR, LOST_STR}
         self.player.board.check_hit_on_other(coordinate, hit)
 
         if result == LOST_STR:
-            ui.draw(self.player.board, status=WIN_MSG)
+            ui.draw(
+                self.player.board,
+                status=WIN_MSG,
+                commitment_status=self.commitment_status,
+            )
             return False
         return True
 
     def handle_opponent_go(self, ui: PygameUI) -> bool:
-        ui.draw(self.player.board, status="Waiting for opponent...")
-
-        coordinate = Coordinate.from_str(recv())
+        coordinate = Coordinate.from_str(
+            self._recv_with_ui_update(ui, "Waiting for opponent...")
+        )
         hit = self.player.board.check_hit_on_self(coordinate)
         result = (
             LOST_STR
             if hit and self.check_lost()
             else HIT_STR if hit else MISS_STR
         )
-        ui.draw(self.player.board, status="Generating proof...")
+        ui.draw(
+            self.player.board,
+            status="Generating proof...",
+            commitment_status=self.commitment_status,
+        )
         response = make_hit_response(
             coordinate,
             hit=hit,
@@ -86,28 +108,52 @@ class Game:
             commitment=self._commitment(),
             secret=self._secret(),
         )
-        ui.draw(self.player.board, status="Proof generated.")
+        ui.draw(
+            self.player.board,
+            status="Proof generated.",
+            commitment_status=self.commitment_status,
+        )
         send(self.player.conn, response)
 
         if hit and self.check_lost():
             send(self.player.conn, LOST_STR)
-            ui.draw(self.player.board, status="You lost")
+            ui.draw(
+                self.player.board,
+                status="You lost",
+                commitment_status=self.commitment_status,
+            )
             return False
 
         return True
 
     def run(self, ui: PygameUI) -> None:
-        ui.draw(self.player.board, status="Exchanging commitments...")
-        self.exchange_commitments()
-        ui.draw(self.player.board, status="Commitments exchanged.")
+        self._exchange_commitments_with_ui_update(ui)
         my_go = self.player.is_host
 
         while self.handle_my_go(ui) if my_go else self.handle_opponent_go(ui):
             my_go = not my_go
 
-    def exchange_commitments(self) -> None:
+    def _exchange_commitments_with_ui_update(self, ui: PygameUI) -> None:
+        self.commitment_status = CommitmentStatus.PENDING
         send(self.player.conn, self._commitment())
-        self.opponent_commitment = recv()
+        self.opponent_commitment = self._recv_with_ui_update(
+            ui, "Exchanging commitments..."
+        )
+        self.commitment_status = CommitmentStatus.VERIFIED
+
+    def _recv_with_ui_update(self, ui: PygameUI, status: str) -> str:
+        duration = 1 / 60  # ~60 FPS
+
+        while True:
+            try:
+                return incoming.get_nowait()
+            except Empty:
+                ui.draw(
+                    self.player.board,
+                    status=status,
+                    commitment_status=self.commitment_status,
+                )
+                sleep(duration)
 
     def _secret(self) -> BattleshipSecret:
         if self.secret is None:

--- a/source/pygame_ui.py
+++ b/source/pygame_ui.py
@@ -6,6 +6,7 @@ from pygame.font import SysFont
 from pygame.time import Clock
 
 from source.board import Board
+from source.commitment_status import CommitmentStatus
 from source.constants import N_COLS, N_ROWS, OTHER_BOARD, OWN_BOARD
 from source.coordinate import Coordinate
 from source.orientation import Orientation
@@ -86,6 +87,7 @@ class PygameUI:
         board: Board,
         status: str = "",
         hover_other: tuple[int, int] | None = None,
+        commitment_status: CommitmentStatus | None = None,
     ) -> None:
         self._fill_background()
         self._draw_board(
@@ -103,15 +105,26 @@ class PygameUI:
             text = self.font.render(status, True, (240, 240, 240))
             self.screen.blit(text, (self.PAD, 8))
 
+        if commitment_status is not None:
+            self._draw_commitment_status(commitment_status)
+
         display.flip()
         self.clock.tick(self.FPS)
 
     def wait_for_target_click(
-        self, board: Board, status: str = ""
+        self,
+        board: Board,
+        status: str = "",
+        commitment_status: CommitmentStatus | None = None,
     ) -> tuple[int, int] | None:
         while True:
             hover_cell = self._hoverable_other_cell(board)
-            self.draw(board, status=status, hover_other=hover_cell)
+            self.draw(
+                board,
+                status=status,
+                hover_other=hover_cell,
+                commitment_status=commitment_status,
+            )
 
             for event in pygame.event.get():
                 if event.type == QUIT:
@@ -243,6 +256,34 @@ class PygameUI:
         if square == Square.SHIP and not hide_ships:
             return 70, 190, 120
         return 36, 48, 66
+
+    def _draw_commitment_status(
+        self, commitment_status: CommitmentStatus
+    ) -> None:
+        box_size = 16
+        box_padding = 4
+        screen_width = self.screen.get_width()
+        box_x = screen_width - self.PAD - box_size - box_padding
+        box_y = 8
+
+        if commitment_status == CommitmentStatus.PENDING:
+            color = (255, 200, 0)  # Yellow
+            label = "ZKP: Pending"
+        elif commitment_status == CommitmentStatus.VERIFIED:
+            color = (50, 200, 80)  # Green
+            label = "ZKP: Verified"
+        elif commitment_status == CommitmentStatus.FAILED:
+            color = (220, 70, 70)  # Red
+            label = "ZKP: Failed"
+        else:
+            raise ValueError("Invalid commitment status")
+
+        rect = Rect(box_x, box_y, box_size, box_size)
+        draw.rect(self.screen, color, rect)
+        draw.rect(self.screen, (200, 200, 200), rect, width=1)
+
+        text = self.small.render(label, True, color)
+        self.screen.blit(text, (box_x - 110, box_y + 2))
 
     @staticmethod
     def _hover_color(color: tuple[int, int, int]) -> tuple[int, int, int]:


### PR DESCRIPTION
- Again, quick and dirty.
- Runs in background so that play can continue while verifying.
  - Will be more important if proof sizes increase.
- With help from Copilot, my G.
- Closes #12.